### PR TITLE
feat: :sparkles: Operaciones de customer en bookings añadidas

### DIFF
--- a/src/main/java/acme/entities/bookings/Booking.java
+++ b/src/main/java/acme/entities/bookings/Booking.java
@@ -12,8 +12,6 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.Valid;
 
-import org.checkerframework.common.aliasing.qual.Unique;
-
 import acme.client.components.basis.AbstractEntity;
 import acme.client.components.datatypes.Money;
 import acme.client.components.mappings.Automapped;
@@ -24,8 +22,8 @@ import acme.client.components.validation.ValidMoney;
 import acme.client.components.validation.ValidString;
 import acme.constraints.ValidSupportedCurrency;
 import acme.entities.flights.Flight;
+import acme.entities.passengers.Passenger;
 import acme.realms.Customer;
-import acme.realms.Passenger;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -40,7 +38,6 @@ public class Booking extends AbstractEntity {
 
 	// Attributes -------------------------------------------------------------
 
-	@Unique
 	@Mandatory
 	@ValidString(min = 6, max = 8, pattern = "^[A-Z0-9]{6,8}$")
 	@Column(unique = true)
@@ -52,13 +49,12 @@ public class Booking extends AbstractEntity {
 	private Date				purchaseMoment;
 
 	@Mandatory
-	@Valid
 	@Enumerated(EnumType.STRING)
 	@Automapped
 	private TravelClass			travelClass;
 
 	@Mandatory
-	@ValidMoney(min = 0)
+	@ValidMoney(min = 0, max = 1000000)
 	@ValidSupportedCurrency
 	@Automapped
 	private Money				price;
@@ -67,6 +63,10 @@ public class Booking extends AbstractEntity {
 	@ValidString(min = 4, max = 4, pattern = "\\d{4}")
 	@Automapped
 	private String				lastNibble;
+
+	@Mandatory
+	@Automapped
+	private Boolean				isDraftMode;
 
 	// Derived attributes -----------------------------------------------------
 

--- a/src/main/java/acme/entities/passengers/Passenger.java
+++ b/src/main/java/acme/entities/passengers/Passenger.java
@@ -1,5 +1,5 @@
 
-package acme.realms;
+package acme.entities.passengers;
 
 import java.util.Date;
 
@@ -8,9 +8,7 @@ import javax.persistence.Entity;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
-import org.checkerframework.common.aliasing.qual.Unique;
-
-import acme.client.components.basis.AbstractRole;
+import acme.client.components.basis.AbstractEntity;
 import acme.client.components.mappings.Automapped;
 import acme.client.components.validation.Mandatory;
 import acme.client.components.validation.Optional;
@@ -23,7 +21,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-public class Passenger extends AbstractRole {
+public class Passenger extends AbstractEntity {
 
 	// Serialisation version --------------------------------------------------
 
@@ -41,7 +39,6 @@ public class Passenger extends AbstractRole {
 	@Automapped
 	private String				email;
 
-	@Unique
 	@Mandatory
 	@ValidString(min = 6, max = 9, pattern = "^[A-Z0-9]{6,9}$")
 	@Column(unique = true)

--- a/src/main/java/acme/features/customer/booking/CustomerBookingController.java
+++ b/src/main/java/acme/features/customer/booking/CustomerBookingController.java
@@ -1,0 +1,42 @@
+
+package acme.features.customer.booking;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.controllers.AbstractGuiController;
+import acme.client.controllers.GuiController;
+import acme.entities.bookings.Booking;
+import acme.realms.Customer;
+
+@GuiController
+public class CustomerBookingController extends AbstractGuiController<Customer, Booking> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private CustomerBookingListService		listService;
+
+	@Autowired
+	private CustomerBookingShowService		showService;
+
+	@Autowired
+	private CustomerBookingCreateService	createService;
+
+	@Autowired
+	private CustomerBookingUpdateService	updateService;
+
+	// Constructors -----------------------------------------------------------
+
+
+	@PostConstruct
+	protected void initialise() {
+		super.addBasicCommand("list", this.listService);
+		super.addBasicCommand("show", this.showService);
+		super.addBasicCommand("create", this.createService);
+		super.addBasicCommand("update", this.updateService);
+
+	}
+
+}

--- a/src/main/java/acme/features/customer/booking/CustomerBookingCreateService.java
+++ b/src/main/java/acme/features/customer/booking/CustomerBookingCreateService.java
@@ -66,7 +66,7 @@ public class CustomerBookingCreateService extends AbstractGuiService<Customer, B
 		auxMon.setAmount(0.0);
 		auxMon.setCurrency("EUR");
 
-		booking.setPrice(flight != null ? flight.getCost() : auxMon);
+		booking.setPrice(auxMon);
 
 		String passportNumber = super.getRequest().getData("passportNumber", String.class);
 
@@ -99,6 +99,8 @@ public class CustomerBookingCreateService extends AbstractGuiService<Customer, B
 
 	@Override
 	public void perform(final Booking booking) {
+		booking.setPrice(booking.getFlight().getCost());
+
 		this.repository.save(booking);
 	}
 

--- a/src/main/java/acme/features/customer/booking/CustomerBookingCreateService.java
+++ b/src/main/java/acme/features/customer/booking/CustomerBookingCreateService.java
@@ -1,0 +1,144 @@
+
+package acme.features.customer.booking;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.datatypes.Money;
+import acme.client.components.models.Dataset;
+import acme.client.components.views.SelectChoices;
+import acme.client.helpers.MomentHelper;
+import acme.client.helpers.RandomHelper;
+import acme.client.services.AbstractGuiService;
+import acme.client.services.GuiService;
+import acme.entities.bookings.Booking;
+import acme.entities.bookings.TravelClass;
+import acme.entities.flights.Flight;
+import acme.entities.passengers.Passenger;
+import acme.realms.Customer;
+
+@GuiService
+public class CustomerBookingCreateService extends AbstractGuiService<Customer, Booking> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private CustomerBookingRepository repository;
+
+	// AbstractGuiService interface -------------------------------------------
+
+
+	@Override
+	public void authorise() {
+		super.getResponse().setAuthorised(super.getRequest().getPrincipal().hasRealmOfType(Customer.class));
+	}
+
+	@Override
+	public void load() {
+		Customer customer;
+		Booking booking;
+
+		customer = (Customer) super.getRequest().getPrincipal().getRealmOfType(Customer.class);
+
+		booking = new Booking();
+		booking.setCustomer(customer);
+		booking.setIsDraftMode(true);
+
+		super.getBuffer().addData(booking);
+	}
+
+	@Override
+	public void bind(final Booking booking) {
+		int flightId;
+		Flight flight;
+
+		super.bindObject(booking, "locatorCode", "travelClass", "lastNibble", "isDraftMode");
+
+		booking.setPurchaseMoment(MomentHelper.getCurrentMoment());
+
+		flightId = super.getRequest().getData("flight", int.class);
+		flight = this.repository.findFlightById(flightId);
+
+		booking.setFlight(flight);
+
+		Money auxMon = new Money();
+		auxMon.setAmount(0.0);
+		auxMon.setCurrency("EUR");
+
+		booking.setPrice(flight != null ? flight.getCost() : auxMon);
+
+		String passportNumber = super.getRequest().getData("passportNumber", String.class);
+
+		booking.setPassenger(this.repository.findPassengerByPassportNumber(passportNumber));
+
+	}
+
+	@Override
+	public void validate(final Booking booking) {
+		String lastNibble;
+		String passportNumber;
+
+		int flightId;
+		flightId = super.getRequest().getData("flight", int.class);
+		Flight flight = this.repository.findFlightById(flightId);
+		super.state(flight != null, "flight", "customer.booking.create.flight-does-not-exist");
+
+		lastNibble = super.getRequest().getData("lastNibble", String.class);
+
+		passportNumber = super.getRequest().getData("passportNumber", String.class);
+		Passenger passenger = this.repository.findPassengerByPassportNumber(passportNumber);
+
+		super.state(booking.getTravelClass() != null, "travelClass", "customer.booking.create.travel-class-does-not-exist");
+
+		super.state(passenger != null, "passportNumber", "customer.booking.create.passenger-does-not-exist");
+
+		super.state(booking.getIsDraftMode() || !lastNibble.isBlank(), "isDraftMode", "customer.booking.create.cant-be-published");
+
+	}
+
+	@Override
+	public void perform(final Booking booking) {
+		this.repository.save(booking);
+	}
+
+	@Override
+	public void unbind(final Booking booking) {
+		Dataset dataset;
+
+		if (super.getBuffer().getErrors().hasErrors()) {
+			booking.setIsDraftMode(true);
+			System.out.print(super.getBuffer().getErrors());
+		}
+
+		int firstUppercaseIndex = 'A';
+		String locatorCode = "";
+		boolean uniqueLocatorCode = false;
+
+		while (!uniqueLocatorCode) {
+			for (int i = 0; i < RandomHelper.nextInt(6, 8); i++) {
+				Integer letterIndex = RandomHelper.nextInt(26);
+				locatorCode += (char) (firstUppercaseIndex + letterIndex);
+			}
+			uniqueLocatorCode = this.repository.findBookingByLocatorCode(locatorCode).isEmpty();
+		}
+		SelectChoices travelClasses;
+		Collection<Flight> flights = this.repository.findAllFlightsForBooking();
+
+		travelClasses = SelectChoices.from(TravelClass.class, booking.getTravelClass());
+
+		SelectChoices flightChoices = new SelectChoices();
+		flights.stream().forEach(f -> flightChoices.add(String.valueOf(f.getId()), String.format("%s - %s - %s", f.getOrigin(), f.getDestiny(), f.getCost()), false));
+		flightChoices.add("0", "----", true);
+
+		dataset = super.unbindObject(booking, "travelClass", "lastNibble", "isDraftMode");
+		dataset.put("locatorCode", locatorCode);
+		dataset.put("travelClasses", travelClasses);
+		dataset.put("flight", "0");
+		dataset.put("flightChoices", flightChoices);
+		dataset.put("passportNumber", "");
+
+		super.getResponse().addData(dataset);
+	}
+
+}

--- a/src/main/java/acme/features/customer/booking/CustomerBookingListService.java
+++ b/src/main/java/acme/features/customer/booking/CustomerBookingListService.java
@@ -1,0 +1,56 @@
+
+package acme.features.customer.booking;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.models.Dataset;
+import acme.client.services.AbstractGuiService;
+import acme.client.services.GuiService;
+import acme.entities.bookings.Booking;
+import acme.entities.passengers.Passenger;
+import acme.realms.Customer;
+
+@GuiService
+public class CustomerBookingListService extends AbstractGuiService<Customer, Booking> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private CustomerBookingRepository repository;
+
+	// AbstractGuiService interface -------------------------------------------
+
+
+	@Override
+	public void authorise() {
+		super.getResponse().setAuthorised(true);
+	}
+
+	@Override
+	public void load() {
+		Collection<Booking> bookings;
+		int customerId;
+
+		customerId = super.getRequest().getPrincipal().getActiveRealm().getId();
+		bookings = this.repository.findBookingByCustomerId(customerId);
+
+		super.getBuffer().addData(bookings);
+	}
+
+	@Override
+	public void unbind(final Booking bookings) {
+		Dataset dataset;
+		Passenger passenger = bookings.getPassenger();
+
+		dataset = super.unbindObject(bookings, "locatorCode", "purchaseMoment", "travelClass", "price", "isDraftMode");
+
+		dataset.put("fullName", passenger.getFullName());
+
+		dataset.put("email", passenger.getEmail());
+
+		super.getResponse().addData(dataset);
+	}
+
+}

--- a/src/main/java/acme/features/customer/booking/CustomerBookingListService.java
+++ b/src/main/java/acme/features/customer/booking/CustomerBookingListService.java
@@ -25,7 +25,7 @@ public class CustomerBookingListService extends AbstractGuiService<Customer, Boo
 
 	@Override
 	public void authorise() {
-		super.getResponse().setAuthorised(true);
+		super.getResponse().setAuthorised(super.getRequest().getPrincipal().hasRealmOfType(Customer.class));
 	}
 
 	@Override

--- a/src/main/java/acme/features/customer/booking/CustomerBookingRepository.java
+++ b/src/main/java/acme/features/customer/booking/CustomerBookingRepository.java
@@ -1,0 +1,39 @@
+
+package acme.features.customer.booking;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import acme.client.repositories.AbstractRepository;
+import acme.entities.bookings.Booking;
+import acme.entities.flights.Flight;
+import acme.entities.passengers.Passenger;
+
+@Repository
+public interface CustomerBookingRepository extends AbstractRepository {
+
+	@Query("select b from Booking b where b.id = :id")
+	Booking findBookingById(int id);
+
+	@Query("select b from Booking b where b.locatorCode = :locatorCode")
+	Optional<Booking> findBookingByLocatorCode(String locatorCode);
+
+	@Query("select b from Booking b where b.customer.id = :customerId")
+	Collection<Booking> findBookingByCustomerId(int customerId);
+
+	@Query("select f from Flight f where f.isDraftMode = false")
+	Collection<Flight> findAllFlightsForBooking();
+
+	@Query("select f from Flight f where f.id = :id")
+	Flight findFlightById(int id);
+
+	@Query("select p from Passenger p")
+	Collection<Passenger> findAllPassengers();
+
+	@Query("select p from Passenger p where p.passportNumber = :passportNumber")
+	Passenger findPassengerByPassportNumber(String passportNumber);
+
+}

--- a/src/main/java/acme/features/customer/booking/CustomerBookingShowService.java
+++ b/src/main/java/acme/features/customer/booking/CustomerBookingShowService.java
@@ -1,0 +1,77 @@
+
+package acme.features.customer.booking;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.models.Dataset;
+import acme.client.components.views.SelectChoices;
+import acme.client.services.AbstractGuiService;
+import acme.client.services.GuiService;
+import acme.entities.bookings.Booking;
+import acme.entities.bookings.TravelClass;
+import acme.entities.flights.Flight;
+import acme.realms.Customer;
+
+@GuiService
+public class CustomerBookingShowService extends AbstractGuiService<Customer, Booking> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private CustomerBookingRepository repository;
+
+	// AbstractGuiService interface -------------------------------------------
+
+
+	@Override
+	public void authorise() {
+		boolean status;
+		int bookingId;
+		Booking booking;
+
+		bookingId = super.getRequest().getData("id", int.class);
+		booking = this.repository.findBookingById(bookingId);
+		status = super.getRequest().getPrincipal().hasRealmOfType(Customer.class) && super.getRequest().getPrincipal().getRealmOfType(Customer.class).getId() == booking.getCustomer().getId();
+
+		super.getResponse().setAuthorised(status);
+	}
+
+	@Override
+	public void load() {
+		Booking booking;
+		int bookingId;
+
+		bookingId = super.getRequest().getData("id", int.class);
+		booking = this.repository.findBookingById(bookingId);
+
+		super.getBuffer().addData(booking);
+	}
+
+	@Override
+	public void unbind(final Booking booking) {
+		Dataset dataset;
+
+		if (super.getBuffer().getErrors().hasErrors()) {
+			booking.setIsDraftMode(true);
+			System.out.print(super.getBuffer().getErrors());
+		}
+
+		SelectChoices travelClasses;
+		Collection<Flight> flights = this.repository.findAllFlightsForBooking();
+
+		travelClasses = SelectChoices.from(TravelClass.class, booking.getTravelClass());
+
+		SelectChoices flightChoices = new SelectChoices();
+		flights.stream().forEach(f -> flightChoices.add(String.valueOf(f.getId()), String.format("%s - %s - %s", f.getOrigin(), f.getDestiny(), f.getCost()), booking.getFlight().getId() == f.getId()));
+
+		dataset = super.unbindObject(booking, "locatorCode", "purchaseMoment", "travelClass", "lastNibble", "isDraftMode");
+		dataset.put("travelClasses", travelClasses);
+		dataset.put("flightChoices", flightChoices);
+		dataset.put("passportNumber", booking.getPassenger().getPassportNumber());
+
+		super.getResponse().addData(dataset);
+	}
+
+}

--- a/src/main/java/acme/features/customer/booking/CustomerBookingUpdateService.java
+++ b/src/main/java/acme/features/customer/booking/CustomerBookingUpdateService.java
@@ -62,8 +62,6 @@ public class CustomerBookingUpdateService extends AbstractGuiService<Customer, B
 
 		booking.setFlight(flight);
 
-		booking.setPrice(flight.getCost());
-
 		String passportNumber = super.getRequest().getData("passportNumber", String.class);
 
 		booking.setPassenger(this.repository.findPassengerByPassportNumber(passportNumber));
@@ -92,6 +90,8 @@ public class CustomerBookingUpdateService extends AbstractGuiService<Customer, B
 
 	@Override
 	public void perform(final Booking booking) {
+		booking.setPrice(booking.getFlight().getCost());
+
 		this.repository.save(booking);
 	}
 

--- a/src/main/java/acme/features/customer/booking/CustomerBookingUpdateService.java
+++ b/src/main/java/acme/features/customer/booking/CustomerBookingUpdateService.java
@@ -1,0 +1,123 @@
+
+package acme.features.customer.booking;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.models.Dataset;
+import acme.client.components.views.SelectChoices;
+import acme.client.services.AbstractGuiService;
+import acme.client.services.GuiService;
+import acme.entities.bookings.Booking;
+import acme.entities.bookings.TravelClass;
+import acme.entities.flights.Flight;
+import acme.entities.passengers.Passenger;
+import acme.realms.Customer;
+
+@GuiService
+public class CustomerBookingUpdateService extends AbstractGuiService<Customer, Booking> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private CustomerBookingRepository repository;
+
+	// AbstractGuiService interface -------------------------------------------
+
+
+	@Override
+	public void authorise() {
+		boolean status;
+		int bookingId;
+		Booking booking;
+
+		bookingId = super.getRequest().getData("id", int.class);
+		booking = this.repository.findBookingById(bookingId);
+		status = super.getRequest().getPrincipal().hasRealmOfType(Customer.class) && super.getRequest().getPrincipal().getRealmOfType(Customer.class).getId() == booking.getCustomer().getId();
+
+		super.getResponse().setAuthorised(status);
+	}
+
+	@Override
+	public void load() {
+		Booking booking;
+		int bookingId;
+
+		bookingId = super.getRequest().getData("id", int.class);
+		booking = this.repository.findBookingById(bookingId);
+
+		super.getBuffer().addData(booking);
+	}
+
+	@Override
+	public void bind(final Booking booking) {
+		super.bindObject(booking, "locatorCode", "travelClass", "lastNibble", "isDraftMode");
+
+		Flight flight;
+		int flightId;
+
+		flightId = super.getRequest().getData("flight", int.class);
+		flight = this.repository.findFlightById(flightId);
+
+		booking.setFlight(flight);
+
+		booking.setPrice(flight.getCost());
+
+		String passportNumber = super.getRequest().getData("passportNumber", String.class);
+
+		booking.setPassenger(this.repository.findPassengerByPassportNumber(passportNumber));
+	}
+
+	@Override
+	public void validate(final Booking booking) {
+		String lastNibble;
+		String passportNumber;
+		Integer flightId;
+
+		lastNibble = super.getRequest().getData("lastNibble", String.class);
+
+		passportNumber = super.getRequest().getData("passportNumber", String.class);
+		Passenger passenger = this.repository.findPassengerByPassportNumber(passportNumber);
+
+		flightId = super.getRequest().getData("flight", int.class);
+		Flight flight = this.repository.findFlightById(flightId);
+
+		super.state(flight != null, "flight", "customer.booking.update.flight-does-not-exist");
+
+		super.state(passenger != null, "passportNumber", "customer.booking.update.passenger-does-not-exist");
+
+		super.state(booking.getIsDraftMode() || !lastNibble.isBlank(), "isDraftMode", "customer.booking.update.cant-be-published");
+	}
+
+	@Override
+	public void perform(final Booking booking) {
+		this.repository.save(booking);
+	}
+
+	@Override
+	public void unbind(final Booking booking) {
+		Dataset dataset;
+
+		if (super.getBuffer().getErrors().hasErrors()) {
+			booking.setIsDraftMode(true);
+			System.out.print(super.getBuffer().getErrors());
+		}
+
+		SelectChoices travelClasses;
+		Collection<Flight> flights = this.repository.findAllFlightsForBooking();
+
+		travelClasses = SelectChoices.from(TravelClass.class, booking.getTravelClass());
+
+		SelectChoices flightChoices = new SelectChoices();
+		flights.stream().forEach(f -> flightChoices.add(String.valueOf(f.getId()), String.format("%s - %s - %s", f.getOrigin(), f.getDestiny(), f.getCost()), booking.getFlight().getId() == f.getId()));
+
+		dataset = super.unbindObject(booking, "locatorCode", "purchaseMoment", "travelClass", "lastNibble", "isDraftMode");
+		dataset.put("travelClasses", travelClasses);
+		dataset.put("flightChoices", flightChoices);
+		dataset.put("passportNumber", booking.getPassenger().getPassportNumber());
+
+		super.getResponse().addData(dataset);
+	}
+
+}

--- a/src/main/java/acme/realms/Customer.java
+++ b/src/main/java/acme/realms/Customer.java
@@ -4,8 +4,6 @@ package acme.realms;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
-import org.checkerframework.common.aliasing.qual.Unique;
-
 import acme.client.components.basis.AbstractRole;
 import acme.client.components.mappings.Automapped;
 import acme.client.components.validation.Mandatory;
@@ -26,7 +24,6 @@ public class Customer extends AbstractRole {
 
 	// Attributes -------------------------------------------------------------
 
-	@Unique
 	@Mandatory
 	@ValidString(min = 8, max = 9, pattern = "^[A-Z]{2,3}\\d{6}$")
 	@Column(unique = true)

--- a/src/main/resources/WEB-INF/data/sample/booking.csv
+++ b/src/main/resources/WEB-INF/data/sample/booking.csv
@@ -1,4 +1,4 @@
-key,locator-code,purchase-moment,travel-class,price,last-nibble,key:flight,key:passenger,key:customer
-booking-01,"R8GJ4NDI",2001/04/10 12:00,ECONOMY,EUR 20.00,"1234",flight-01,passenger-01,customer-01
-booking-02,"098765",2003/08/04 08:30,ECONOMY,EUR 50.00,"9535",flight-01,passenger-02,customer-02
-booking-03,"MFURBWK",2004/05/08 15:45,BUSINESS,EUR 200.00,"3435",flight-01,passenger-03,customer-02
+key,locator-code,purchase-moment,travel-class,price,is_draft_mode,last-nibble,key:flight,key:passenger,key:customer
+booking-01,R8GJ4NDI,2001/04/10 12:00,ECONOMY,EUR 20.00,false,1234,flight-01,passenger-01,customer-01
+booking-02,098765,2003/08/04 08:30,ECONOMY,EUR 50.00,false,9535,flight-01,passenger-02,customer-02
+booking-03,MFURBWK,2004/05/08 15:45,BUSINESS,EUR 200.00,false,3435,flight-01,passenger-03,customer-02

--- a/src/main/resources/WEB-INF/data/sample/passenger.csv
+++ b/src/main/resources/WEB-INF/data/sample/passenger.csv
@@ -1,4 +1,4 @@
-key,key:userAccount,full-name,email,passport-number,date-of-birth,special-needs
-passenger-01,user-account-customer-01,"Rosa Martinez","eltioraperas@gmail.com","R8GJ4NDI3",1980/10/01 00:00,""
-passenger-02,user-account-customer-01,"Pipo Moralea","estonoesunacuentafalsa@hotmail.com","098765",2000/03/07 00:00,""
-passenger-03,user-account-customer-01,"Rei Fujisaki","uwu@gmail.com","MFURBWKGN",1973/11/20 00:00,"Peanut allergy"
+key,full-name,email,passport-number,date-of-birth,special-needs
+passenger-01,Rosa Martinez,eltioraperas@gmail.com,R8GJ4NDI3,1980/10/01 00:00,""
+passenger-02,Pipo Moralea,estonoesunacuentafalsa@hotmail.com,098765,2000/03/07 00:00,""
+passenger-03,Rei Fujisaki,uwu@gmail.com,MFURBWKGN,1973/11/20 00:00,Peanut allergy

--- a/src/main/resources/WEB-INF/views/customer/booking/form.jsp
+++ b/src/main/resources/WEB-INF/views/customer/booking/form.jsp
@@ -1,0 +1,22 @@
+<%@page%>
+
+<%@taglib prefix="jstl" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@taglib prefix="acme" uri="http://acme-framework.org/"%>
+
+<acme:form>
+	<acme:input-textbox code="customer.booking.form.label.locatorCode" path="locatorCode" readonly="true"/>
+	<acme:input-select code="customer.booking.form.label.flight" path="flight" choices="${flightChoices}"/>
+	<acme:input-select code="customer.booking.form.label.travelClass" path="travelClass" choices="${travelClasses}"/>
+	<acme:input-textbox code="customer.booking.form.label.passportNumber" path="passportNumber"/>
+	<acme:input-textbox code="customer.booking.form.label.lastNibble" path="lastNibble"/>
+	<acme:input-checkbox code="customer.booking.form.label.isDraftMode" path="isDraftMode"/>	
+	
+	<jstl:choose>
+		<jstl:when test="${acme:anyOf(_command, 'show|update') && isDraftMode == true}">
+			<acme:submit code="customer.booking.form.button.update" action="/customer/booking/update"/>
+		</jstl:when>
+		<jstl:when test="${_command == 'create'}">
+			<acme:submit code="customer.booking.form.button.create" action="/customer/booking/create"/>
+		</jstl:when>		
+	</jstl:choose>
+</acme:form>

--- a/src/main/resources/WEB-INF/views/customer/booking/list.jsp
+++ b/src/main/resources/WEB-INF/views/customer/booking/list.jsp
@@ -1,0 +1,19 @@
+<%@page%>
+
+<%@taglib prefix="jstl" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@taglib prefix="acme" uri="http://acme-framework.org/"%>
+
+<acme:list>
+	<acme:list-column code="customer.booking.list.label.locatorCode" path="locatorCode" width="20%"/>
+	<acme:list-column code="customer.booking.list.label.purchaseMoment" path="purchaseMoment" width="20%"/>
+	<acme:list-column code="customer.booking.list.label.travelClass" path="travelClass" width="20%"/>
+	<acme:list-column code="customer.booking.list.label.price" path="price" width="20%"/>
+	<acme:list-column code="customer.booking.list.label.isDraftMode" path="isDraftMode" width="20%"/>
+	
+	<acme:list-column code="customer.booking.list.label.fullName" path="fullName" width="20%"/>
+	<acme:list-column code="customer.booking.list.label.email" path="email" width="10%"/>
+	
+	
+</acme:list>
+
+<acme:button code="customer.booking.list.button.create" action="/customer/booking/create"/>

--- a/src/main/resources/WEB-INF/views/customer/booking/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/customer/booking/messages-en.i18n
@@ -1,0 +1,33 @@
+customer.booking.form.title = Booking form
+customer.booking.list.title = Listing of bookings
+
+customer.booking.list.label.locatorCode = Locator Code
+customer.booking.list.label.purchaseMoment = Purchase Moment
+customer.booking.list.label.travelClass = Travel Class
+customer.booking.list.label.price = Price
+customer.booking.list.label.isDraftMode = Draft mode?
+customer.booking.list.label.fullName = Passenger
+customer.booking.list.label.email = Passenger email
+
+
+customer.booking.list.button.create = Create new booking
+
+customer.booking.form.label.locatorCode = Locator Code
+customer.booking.form.label.flight = Flight
+customer.booking.form.label.travelClass = Travel Class
+customer.booking.form.label.isDraftMode = Draft mode?
+customer.booking.form.label.passportNumber = Passenger passport
+customer.booking.form.label.lastNibble = Last nibble of the credit card
+
+customer.booking.form.button.update = Update this booking
+customer.booking.form.button.create = Create this booking
+
+customer.booking.create.flight-does-not-exist = Choose a flight
+customer.booking.create.passenger-does-not-exist = There is no passenger registered with that passport
+customer.booking.create.travel-class-does-not-exist = Choose a travel class
+customer.booking.create.cant-be-published = You can't publish this booking because it does not have the last nibble
+
+customer.booking.update.flight-does-not-exist = Choose a flight
+customer.booking.update.passenger-does-not-exist = There is no passenger registered with that passport
+customer.booking.update.travel-class-does-not-exist = Choose a travel class
+customer.booking.update.cant-be-published = You can't publish this booking because it does not have the last nibble

--- a/src/main/resources/WEB-INF/views/customer/booking/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/customer/booking/messages-es.i18n
@@ -1,0 +1,32 @@
+customer.booking.form.title = Formulario de reservas
+customer.booking.list.title = Listado de reservas
+
+customer.booking.list.label.locatorCode = Localizador
+customer.booking.list.label.purchaseMoment = Fecha de compra
+customer.booking.list.label.travelClass = Clase
+customer.booking.list.label.price = Precio
+customer.booking.list.label.isDraftMode = ¿Borrador?
+customer.booking.list.label.fullName = Pasajero
+customer.booking.list.label.email = Email del pasajero
+
+customer.booking.list.button.create = Crear nueva reserva
+
+customer.booking.form.label.locatorCode = Localizador
+customer.booking.form.label.flight = Vuelo
+customer.booking.form.label.travelClass = Clase
+customer.booking.form.label.isDraftMode = ¿Modo borrador?
+customer.booking.form.label.passportNumber = Pasaporte del pasajero
+customer.booking.form.label.lastNibble = Últimos dígitos de la tarjeta de crédito
+
+customer.booking.form.button.create = Crear nueva reserva
+customer.booking.form.button.update = Actualizar reserva
+
+customer.booking.create.flight-does-not-exist = Escoge un vuelo
+customer.booking.create.passenger-does-not-exist = No hay ningún pasajero registrado con ese pasaporte
+customer.booking.create.travel-class-does-not-exist = Escoge una clase
+customer.booking.create.cant-be-published = No se puede publicar sin los último dígitos de la tarjeta
+
+customer.booking.update.flight-does-not-exist = Escoge un vuelo
+customer.booking.update.passenger-does-not-exist = No hay ningún pasajero registrado con ese pasaporte
+customer.booking.update.travel-class-does-not-exist = Escoge una clase
+customer.booking.update.cant-be-published = No se puede publicar sin los último dígitos de la tarjeta

--- a/src/main/resources/WEB-INF/views/fragments/menu-en.i18n
+++ b/src/main/resources/WEB-INF/views/fragments/menu-en.i18n
@@ -56,6 +56,12 @@ master.menu.manager.create-legs = Create legs
 master.menu.manager.list-flights = List flights
 master.menu.manager.create-flights = Create flights
 
+# master.menu.customer ##########################################################
+
+master.menu.customer = Customer
+master.menu.customer.list-booking = List bookings
+master.menu.customer.create-booking = Create bookings
+
 # master.menu.user-account ####################################################
 
 master.menu.user-account = Account

--- a/src/main/resources/WEB-INF/views/fragments/menu-es.i18n
+++ b/src/main/resources/WEB-INF/views/fragments/menu-es.i18n
@@ -56,6 +56,12 @@ master.menu.manager.create-legs = Crear tramos de vuelo
 master.menu.manager.list-flights = Ver vuelos
 master.menu.manager.create-flights = Crear vuelos
 
+# master.menu.customer ##########################################################
+
+master.menu.customer = Cliente
+master.menu.customer.list-booking = Ver reservas
+master.menu.customer.create-booking = Crear reservas
+
 # master.menu.user-account ####################################################
 
 master.menu.user-account = Cuenta

--- a/src/main/resources/WEB-INF/views/fragments/menu.jsp
+++ b/src/main/resources/WEB-INF/views/fragments/menu.jsp
@@ -63,6 +63,10 @@
 			<acme:menu-suboption code="master.menu.manager.list-flights" action="/manager/flight/list"/>
 			<acme:menu-suboption code="master.menu.manager.create-flights" action="/manager/flight/create"/>
 		</acme:menu-option>
+		<acme:menu-option code="master.menu.customer" access="hasRealm('Customer')">
+			<acme:menu-suboption code="master.menu.customer.list-booking" action="/customer/booking/list"/>
+			<acme:menu-suboption code="master.menu.customer.create-booking" action="/customer/booking/create"/>
+		</acme:menu-option>
 	</acme:menu-left>
 
 	<acme:menu-right>		


### PR DESCRIPTION
Se han añadido las operaciones de visualizar, crear, y editar reservas para un cliente.

Algunos tips para usarlo:

* Iniciar sesión como alguno de los clientes (customer1, customer2...) para poder hacer las operaciones.
* Al hacer la reserva, solo permite elegir los vuelos que estén publicados (no tendría sentido que no fuera así).
* Algunos pasaportes que se pueden usar para añadir pasajeros son: R8GJ4NDI3, 098765, MFURBWKGN.
* El "lastNibble" son los últimos 4 dígitos de la tarjeta.
* El localizador se genera automáticamente por el sistema, por eso no hace falta escribirlo.

Refs: #189