### PR TITLE
30 operaciones de administradores en servicios

### DIFF
--- a/src/main/java/acme/entities/services/Service.java
+++ b/src/main/java/acme/entities/services/Service.java
@@ -1,7 +1,6 @@
 
 package acme.entities.services;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.validation.Valid;
@@ -48,7 +47,7 @@ public class Service extends AbstractEntity {
 
 	@Optional
 	@ValidString(min = 7, max = 7, pattern = "^[A-Z]{4}-[0-9]{2}$")
-	@Column(unique = true)
+	@Automapped
 	private String				promotionCode;
 
 	@Optional

--- a/src/main/java/acme/entities/services/Service.java
+++ b/src/main/java/acme/entities/services/Service.java
@@ -1,6 +1,7 @@
 
 package acme.entities.services;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.validation.Valid;
@@ -47,7 +48,7 @@ public class Service extends AbstractEntity {
 
 	@Optional
 	@ValidString(min = 7, max = 7, pattern = "^[A-Z]{4}-[0-9]{2}$")
-	@Automapped
+	@Column(unique = true)
 	private String				promotionCode;
 
 	@Optional

--- a/src/main/java/acme/features/administrator/service/AdministratorServiceController.java
+++ b/src/main/java/acme/features/administrator/service/AdministratorServiceController.java
@@ -16,31 +16,27 @@ public class AdministratorServiceController extends AbstractGuiController<Admini
 	// Internal state ---------------------------------------------------------
 
 	@Autowired
-	AdministratorServiceListService listService;
+	AdministratorServiceListService		listService;
 
-	/*
-	 * 
-	 * 
-	 * @Autowired
-	 * AdministratorAirportShowService showService;
-	 * 
-	 * @Autowired
-	 * AdministratorAirportUpdateService updateService;
-	 * 
-	 * @Autowired
-	 * AdministratorAirportCreateService createService;
-	 **/
+	@Autowired
+	AdministratorServiceShowService		showService;
+
+	@Autowired
+	AdministratorServiceUpdateService	updateService;
+
+	@Autowired
+	AdministratorServiceCreateService	createService;
+
 	// Constructors -----------------------------------------------------------
 
 
 	@PostConstruct
 	protected void initialise() {
 		super.addBasicCommand("list", this.listService);
-		/*
-		 * super.addBasicCommand("show", this.showService);
-		 * super.addBasicCommand("update", this.updateService);
-		 * super.addBasicCommand("create", this.createService);
-		 */
+		super.addBasicCommand("show", this.showService);
+		super.addBasicCommand("update", this.updateService);
+		super.addBasicCommand("create", this.createService);
+
 	}
 
 }

--- a/src/main/java/acme/features/administrator/service/AdministratorServiceController.java
+++ b/src/main/java/acme/features/administrator/service/AdministratorServiceController.java
@@ -1,0 +1,46 @@
+
+package acme.features.administrator.service;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.principals.Administrator;
+import acme.client.controllers.AbstractGuiController;
+import acme.client.controllers.GuiController;
+import acme.entities.services.Service;
+
+@GuiController
+public class AdministratorServiceController extends AbstractGuiController<Administrator, Service> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	AdministratorServiceListService listService;
+
+	/*
+	 * 
+	 * 
+	 * @Autowired
+	 * AdministratorAirportShowService showService;
+	 * 
+	 * @Autowired
+	 * AdministratorAirportUpdateService updateService;
+	 * 
+	 * @Autowired
+	 * AdministratorAirportCreateService createService;
+	 **/
+	// Constructors -----------------------------------------------------------
+
+
+	@PostConstruct
+	protected void initialise() {
+		super.addBasicCommand("list", this.listService);
+		/*
+		 * super.addBasicCommand("show", this.showService);
+		 * super.addBasicCommand("update", this.updateService);
+		 * super.addBasicCommand("create", this.createService);
+		 */
+	}
+
+}

--- a/src/main/java/acme/features/administrator/service/AdministratorServiceController.java
+++ b/src/main/java/acme/features/administrator/service/AdministratorServiceController.java
@@ -27,6 +27,9 @@ public class AdministratorServiceController extends AbstractGuiController<Admini
 	@Autowired
 	AdministratorServiceCreateService	createService;
 
+	@Autowired
+	AdministratorServiceDeleteService	deleteService;
+
 	// Constructors -----------------------------------------------------------
 
 
@@ -36,6 +39,7 @@ public class AdministratorServiceController extends AbstractGuiController<Admini
 		super.addBasicCommand("show", this.showService);
 		super.addBasicCommand("update", this.updateService);
 		super.addBasicCommand("create", this.createService);
+		super.addBasicCommand("delete", this.deleteService);
 
 	}
 

--- a/src/main/java/acme/features/administrator/service/AdministratorServiceCreateService.java
+++ b/src/main/java/acme/features/administrator/service/AdministratorServiceCreateService.java
@@ -1,0 +1,85 @@
+
+package acme.features.administrator.service;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.models.Dataset;
+import acme.client.components.principals.Administrator;
+import acme.client.components.views.SelectChoices;
+import acme.client.services.AbstractGuiService;
+import acme.client.services.GuiService;
+import acme.entities.airports.Airport;
+import acme.entities.services.Service;
+
+@GuiService
+public class AdministratorServiceCreateService extends AbstractGuiService<Administrator, Service> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private AdministratorServiceRepository repository;
+
+	// AbstractGuiService interface -------------------------------------------
+
+
+	@Override
+	public void authorise() {
+		super.getResponse().setAuthorised(super.getRequest().getPrincipal().hasRealmOfType(Administrator.class));
+	}
+
+	@Override
+	public void load() {
+		super.getBuffer().addData(new Service());
+	}
+
+	@Override
+	public void bind(final Service service) {
+		int airportId;
+		Airport airport;
+
+		super.bindObject(service, "name", "picture", "avgDwellTime", "promotionCode", "money");
+
+		airportId = super.getRequest().getData("airport", int.class);
+		airport = this.repository.findAirportById(airportId);
+
+		service.setAirport(airport);
+
+	}
+
+	@Override
+	public void validate(final Service service) {
+		int airportId;
+		airportId = super.getRequest().getData("airport", int.class);
+		Airport airport = this.repository.findAirportById(airportId);
+
+		super.state(this.repository.findPromotionCodes().contains(service.getPromotionCode()), "promotionCode", "administrator.service.create.promotion-code-must-be-unique");
+
+		super.state(airport != null, "airport", "administrator.service.create.airport-does-not-exist");
+
+	}
+
+	@Override
+	public void perform(final Service service) {
+		this.repository.save(service);
+	}
+
+	@Override
+	public void unbind(final Service service) {
+		Dataset dataset;
+
+		Collection<Airport> airports = this.repository.findAllAirports();
+
+		SelectChoices airportChoices = new SelectChoices();
+		airports.stream().forEach(a -> airportChoices.add(String.valueOf(a.getId()), String.format("%s - %s", a.getIATACode(), a.getCity()), false));
+		airportChoices.add("0", "----", true);
+
+		dataset = super.unbindObject(service, "name", "picture", "avgDwellTime", "promotionCode", "money");
+		dataset.put("airport", "0");
+		dataset.put("airportChoices", airportChoices);
+
+		super.getResponse().addData(dataset);
+	}
+
+}

--- a/src/main/java/acme/features/administrator/service/AdministratorServiceCreateService.java
+++ b/src/main/java/acme/features/administrator/service/AdministratorServiceCreateService.java
@@ -54,9 +54,9 @@ public class AdministratorServiceCreateService extends AbstractGuiService<Admini
 		airportId = super.getRequest().getData("airport", int.class);
 		Airport airport = this.repository.findAirportById(airportId);
 
-		super.state(this.repository.findPromotionCodes().contains(service.getPromotionCode()), "promotionCode", "administrator.service.create.promotion-code-must-be-unique");
+		super.state(service.getPromotionCode().isBlank() || !this.repository.findPromotionCodes().contains(service.getPromotionCode()), "promotionCode", "administrator.service.update.promotion-code-must-be-unique");
 
-		super.state(airport != null, "airport", "administrator.service.create.airport-does-not-exist");
+		super.state(airport != null, "airport", "administrator.service.update.airport-does-not-exist");
 
 	}
 

--- a/src/main/java/acme/features/administrator/service/AdministratorServiceDeleteService.java
+++ b/src/main/java/acme/features/administrator/service/AdministratorServiceDeleteService.java
@@ -14,7 +14,7 @@ import acme.entities.airports.Airport;
 import acme.entities.services.Service;
 
 @GuiService
-public class AdministratorServiceUpdateService extends AbstractGuiService<Administrator, Service> {
+public class AdministratorServiceDeleteService extends AbstractGuiService<Administrator, Service> {
 
 	// Internal state ---------------------------------------------------------
 
@@ -42,39 +42,17 @@ public class AdministratorServiceUpdateService extends AbstractGuiService<Admini
 
 	@Override
 	public void bind(final Service service) {
-		int airportId;
-		Airport airport;
-
 		super.bindObject(service, "name", "picture", "avgDwellTime", "promotionCode", "money");
-
-		airportId = super.getRequest().getData("airport", int.class);
-		airport = this.repository.findAirportById(airportId);
-
-		service.setAirport(airport);
-
 	}
 
 	@Override
 	public void validate(final Service service) {
-		int airportId;
-		Airport airport;
-		Service oldService;
-		Boolean promoAlreadyUsed;
-
-		airportId = super.getRequest().getData("airport", int.class);
-		airport = this.repository.findAirportById(airportId);
-		oldService = this.repository.findServiceById(service.getId());
-		promoAlreadyUsed = !this.repository.findPromotionCodes().contains(service.getPromotionCode()) || oldService.getPromotionCode().equals(service.getPromotionCode());
-
-		super.state(service.getPromotionCode().isBlank() || promoAlreadyUsed, "promotionCode", "administrator.service.create.promotion-code-must-be-unique");
-
-		super.state(airport != null, "airport", "administrator.service.create.airport-does-not-exist");
 
 	}
 
 	@Override
 	public void perform(final Service service) {
-		this.repository.save(service);
+		this.repository.delete(service);
 	}
 
 	@Override

--- a/src/main/java/acme/features/administrator/service/AdministratorServiceListService.java
+++ b/src/main/java/acme/features/administrator/service/AdministratorServiceListService.java
@@ -1,0 +1,52 @@
+
+package acme.features.administrator.service;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.models.Dataset;
+import acme.client.components.principals.Administrator;
+import acme.client.services.AbstractGuiService;
+import acme.client.services.GuiService;
+import acme.entities.airports.Airport;
+import acme.entities.services.Service;
+
+@GuiService
+public class AdministratorServiceListService extends AbstractGuiService<Administrator, Service> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private AdministratorServiceRepository repository;
+
+	// AbstractGuiService interface -------------------------------------------
+
+
+	@Override
+	public void authorise() {
+		super.getResponse().setAuthorised(super.getRequest().getPrincipal().hasRealmOfType(Administrator.class));
+	}
+
+	@Override
+	public void load() {
+		Collection<Service> services;
+
+		services = this.repository.findAllServices();
+
+		super.getBuffer().addData(services);
+	}
+
+	@Override
+	public void unbind(final Service services) {
+		Dataset dataset;
+		Airport airport = services.getAirport();
+
+		dataset = super.unbindObject(services, "name", "picture", "avgDwellTime", "promotionCode", "money");
+
+		dataset.put("iATACode", airport.getIATACode());
+
+		super.getResponse().addData(dataset);
+	}
+
+}

--- a/src/main/java/acme/features/administrator/service/AdministratorServiceRepository.java
+++ b/src/main/java/acme/features/administrator/service/AdministratorServiceRepository.java
@@ -1,0 +1,18 @@
+
+package acme.features.administrator.service;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import acme.client.repositories.AbstractRepository;
+import acme.entities.services.Service;
+
+@Repository
+public interface AdministratorServiceRepository extends AbstractRepository {
+
+	@Query("SELECT s FROM Service s")
+	List<Service> findAllServices();
+
+}

--- a/src/main/java/acme/features/administrator/service/AdministratorServiceRepository.java
+++ b/src/main/java/acme/features/administrator/service/AdministratorServiceRepository.java
@@ -7,12 +7,25 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import acme.client.repositories.AbstractRepository;
+import acme.entities.airports.Airport;
 import acme.entities.services.Service;
 
 @Repository
 public interface AdministratorServiceRepository extends AbstractRepository {
 
-	@Query("SELECT s FROM Service s")
+	@Query("select s from Service s")
 	List<Service> findAllServices();
+
+	@Query("select s from Service s where s.id = :id")
+	Service findServiceById(int id);
+
+	@Query("select a from Airport a")
+	List<Airport> findAllAirports();
+
+	@Query("select a from Airport a where a.id = :id")
+	Airport findAirportById(int id);
+
+	@Query("select s.promotionCode from Service s")
+	List<String> findPromotionCodes();
 
 }

--- a/src/main/java/acme/features/administrator/service/AdministratorServiceShowService.java
+++ b/src/main/java/acme/features/administrator/service/AdministratorServiceShowService.java
@@ -1,0 +1,59 @@
+
+package acme.features.administrator.service;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.models.Dataset;
+import acme.client.components.principals.Administrator;
+import acme.client.components.views.SelectChoices;
+import acme.client.services.AbstractGuiService;
+import acme.client.services.GuiService;
+import acme.entities.airports.Airport;
+import acme.entities.services.Service;
+
+@GuiService
+public class AdministratorServiceShowService extends AbstractGuiService<Administrator, Service> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private AdministratorServiceRepository repository;
+
+	// AbstractGuiService interface -------------------------------------------
+
+
+	@Override
+	public void authorise() {
+		super.getResponse().setAuthorised(super.getRequest().getPrincipal().hasRealmOfType(Administrator.class));
+	}
+
+	@Override
+	public void load() {
+		Service service;
+		int serviceId;
+
+		serviceId = super.getRequest().getData("id", int.class);
+		service = this.repository.findServiceById(serviceId);
+
+		super.getBuffer().addData(service);
+	}
+
+	@Override
+	public void unbind(final Service service) {
+		Dataset dataset;
+
+		Collection<Airport> airports = this.repository.findAllAirports();
+
+		SelectChoices airportChoices = new SelectChoices();
+		airports.stream().forEach(a -> airportChoices.add(String.valueOf(a.getId()), String.format("%s - %s", a.getIATACode(), a.getCity()), false));
+
+		dataset = super.unbindObject(service, "name", "picture", "avgDwellTime", "promotionCode", "money");
+		dataset.put("airport", "0");
+		dataset.put("airportChoices", airportChoices);
+
+		super.getResponse().addData(dataset);
+	}
+
+}

--- a/src/main/java/acme/features/administrator/service/AdministratorServiceUpdateService.java
+++ b/src/main/java/acme/features/administrator/service/AdministratorServiceUpdateService.java
@@ -1,0 +1,90 @@
+
+package acme.features.administrator.service;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.models.Dataset;
+import acme.client.components.principals.Administrator;
+import acme.client.components.views.SelectChoices;
+import acme.client.services.AbstractGuiService;
+import acme.client.services.GuiService;
+import acme.entities.airports.Airport;
+import acme.entities.services.Service;
+
+@GuiService
+public class AdministratorServiceUpdateService extends AbstractGuiService<Administrator, Service> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private AdministratorServiceRepository repository;
+
+	// AbstractGuiService interface -------------------------------------------
+
+
+	@Override
+	public void authorise() {
+		super.getResponse().setAuthorised(super.getRequest().getPrincipal().hasRealmOfType(Administrator.class));
+	}
+
+	@Override
+	public void load() {
+		Service service;
+		int serviceId;
+
+		serviceId = super.getRequest().getData("id", int.class);
+		service = this.repository.findServiceById(serviceId);
+
+		super.getBuffer().addData(service);
+	}
+
+	@Override
+	public void bind(final Service service) {
+		int airportId;
+		Airport airport;
+
+		super.bindObject(service, "name", "picture", "avgDwellTime", "promotionCode", "money");
+
+		airportId = super.getRequest().getData("airport", int.class);
+		airport = this.repository.findAirportById(airportId);
+
+		service.setAirport(airport);
+
+	}
+
+	@Override
+	public void validate(final Service service) {
+		int airportId;
+		airportId = super.getRequest().getData("airport", int.class);
+		Airport airport = this.repository.findAirportById(airportId);
+
+		super.state(this.repository.findPromotionCodes().contains(service.getPromotionCode()), "promotionCode", "administrator.service.create.promotion-code-must-be-unique");
+
+		super.state(airport != null, "airport", "administrator.service.create.airport-does-not-exist");
+
+	}
+
+	@Override
+	public void perform(final Service service) {
+		this.repository.save(service);
+	}
+
+	@Override
+	public void unbind(final Service service) {
+		Dataset dataset;
+
+		Collection<Airport> airports = this.repository.findAllAirports();
+
+		SelectChoices airportChoices = new SelectChoices();
+		airports.stream().forEach(a -> airportChoices.add(String.valueOf(a.getId()), String.format("%s - %s", a.getIATACode(), a.getCity()), false));
+
+		dataset = super.unbindObject(service, "name", "picture", "avgDwellTime", "promotionCode", "money");
+		dataset.put("airport", "0");
+		dataset.put("airportChoices", airportChoices);
+
+		super.getResponse().addData(dataset);
+	}
+
+}

--- a/src/main/resources/WEB-INF/views/administrator/service/form.jsp
+++ b/src/main/resources/WEB-INF/views/administrator/service/form.jsp
@@ -5,14 +5,14 @@
 
 <acme:form>
 	<acme:input-textbox code="administrator.service.form.label.name" path="name"/>
-	<acme:input-textbox code="administrator.service.form.label.picture" path="picture"/>
-	<acme:input-textbox code="administrator.service.form.label.avgDwellTime" path="avgDwellTime"/>
+	<acme:input-url code="administrator.service.form.label.picture" path="picture"/>
+	<acme:input-double code="administrator.service.form.label.avgDwellTime" path="avgDwellTime"/>
 	<acme:input-textbox code="administrator.service.form.label.promotionCode" path="promotionCode"/>
 	<acme:input-money code="administrator.service.form.label.money" path="money"/>
-	<acme:input-select code="administrator.service.form.label.iATACode" path="iATACode" choices="${airportChoices}"/>
+	<acme:input-select code="administrator.service.form.label.airport" path="airport" choices="${airportChoices}"/>
 	
 	<jstl:choose>
-		<jstl:when test="${acme:anyOf(_command, 'show|update|delete') && isDraftMode == true}">
+		<jstl:when test="${acme:anyOf(_command, 'show|update|delete')}">
 			<acme:submit code="administrator.service.form.button.update" action="/administrator/service/update"/>
 			<acme:submit code="administrator.service.form.button.delete" action="/administrator/service/delete"/>
 		</jstl:when>

--- a/src/main/resources/WEB-INF/views/administrator/service/form.jsp
+++ b/src/main/resources/WEB-INF/views/administrator/service/form.jsp
@@ -1,0 +1,23 @@
+<%@page%>
+
+<%@taglib prefix="jstl" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@taglib prefix="acme" uri="http://acme-framework.org/"%>
+
+<acme:form>
+	<acme:input-textbox code="administrator.service.form.label.name" path="name"/>
+	<acme:input-textbox code="administrator.service.form.label.picture" path="picture"/>
+	<acme:input-textbox code="administrator.service.form.label.avgDwellTime" path="avgDwellTime"/>
+	<acme:input-textbox code="administrator.service.form.label.promotionCode" path="promotionCode"/>
+	<acme:input-money code="administrator.service.form.label.money" path="money"/>
+	<acme:input-select code="administrator.service.form.label.iATACode" path="iATACode" choices="${airportChoices}"/>
+	
+	<jstl:choose>
+		<jstl:when test="${acme:anyOf(_command, 'show|update|delete') && isDraftMode == true}">
+			<acme:submit code="administrator.service.form.button.update" action="/administrator/service/update"/>
+			<acme:submit code="administrator.service.form.button.delete" action="/administrator/service/delete"/>
+		</jstl:when>
+		<jstl:when test="${_command == 'create'}">
+			<acme:submit code="administrator.service.form.button.create" action="/administrator/service/create"/>
+		</jstl:when>		
+	</jstl:choose>
+</acme:form>

--- a/src/main/resources/WEB-INF/views/administrator/service/list.jsp
+++ b/src/main/resources/WEB-INF/views/administrator/service/list.jsp
@@ -1,0 +1,14 @@
+<%@page%>
+
+<%@taglib prefix="jstl" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@taglib prefix="acme" uri="http://acme-framework.org/"%>
+
+<acme:list>
+	<acme:list-column code="administrator.service.list.label.name" path="name" width="10%"/>
+	<acme:list-column code="administrator.service.list.label.avgDwellTime" path="avgDwellTime" width="10%"/>
+	<acme:list-column code="administrator.service.list.label.promotionCode" path="promotionCode" width="10%"/>
+	<acme:list-column code="administrator.service.list.label.money" path="money" width="10%"/>
+	<acme:list-column code="administrator.service.list.label.iATACode" path="iATACode" width="10%"/>
+</acme:list>
+
+<acme:button code="administrator.service.list.button.create" action="/administrator/service/create"/>

--- a/src/main/resources/WEB-INF/views/administrator/service/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/administrator/service/messages-en.i18n
@@ -1,0 +1,22 @@
+administrator.service.form.title = Service form
+administrator.service.list.title = Listing of services
+
+administrator.service.list.label.name = Name
+administrator.service.list.label.picture = Picture
+administrator.service.list.label.avgDwellTime = Average dwell time
+administrator.service.list.label.promotionCode = Promotion Code
+administrator.service.list.label.money = Discount
+administrator.service.list.label.iATACode = IATA Code
+
+administrator.service.list.button.create = Create new service
+
+administrator.service.form.label.name = Name
+administrator.service.form.label.picture = Picture
+administrator.service.form.label.avgDwellTime = Average dwell time
+administrator.service.form.label.promotionCode = Promotion Code
+administrator.service.form.label.money = Discount
+administrator.service.form.label.iATACode = IATA Code
+
+administrator.service.form.button.update = Update this service
+administrator.service.form.button.delete = Delete this service
+administrator.service.form.button.create = Create this service

--- a/src/main/resources/WEB-INF/views/administrator/service/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/administrator/service/messages-en.i18n
@@ -20,3 +20,10 @@ administrator.service.form.label.airport = Airport
 administrator.service.form.button.update = Update this service
 administrator.service.form.button.delete = Delete this service
 administrator.service.form.button.create = Create this service
+
+administrator.service.create.promotion-code-must-be-unique = This promotion code already exists
+administrator.service.create.airport-does-not-exist = Choose an airport
+
+administrator.service.update.promotion-code-must-be-unique = This promotion code already exists
+administrator.service.update.airport-does-not-exist = Choose an airport
+

--- a/src/main/resources/WEB-INF/views/administrator/service/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/administrator/service/messages-en.i18n
@@ -6,7 +6,7 @@ administrator.service.list.label.picture = Picture
 administrator.service.list.label.avgDwellTime = Average dwell time
 administrator.service.list.label.promotionCode = Promotion Code
 administrator.service.list.label.money = Discount
-administrator.service.list.label.iATACode = IATA Code
+administrator.service.list.label.iATACode = Airport
 
 administrator.service.list.button.create = Create new service
 
@@ -15,7 +15,7 @@ administrator.service.form.label.picture = Picture
 administrator.service.form.label.avgDwellTime = Average dwell time
 administrator.service.form.label.promotionCode = Promotion Code
 administrator.service.form.label.money = Discount
-administrator.service.form.label.iATACode = IATA Code
+administrator.service.form.label.airport = Airport
 
 administrator.service.form.button.update = Update this service
 administrator.service.form.button.delete = Delete this service

--- a/src/main/resources/WEB-INF/views/administrator/service/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/administrator/service/messages-es.i18n
@@ -1,0 +1,22 @@
+administrator.service.form.title = Formulario de servicios
+administrator.service.list.title = Listado de servicios
+
+administrator.service.list.label.name = Nombre
+administrator.service.list.label.picture = Imagen
+administrator.service.list.label.avgDwellTime = Tiempo de permanencia
+administrator.service.list.label.promotionCode = Código de promo
+administrator.service.list.label.money = Descuento
+administrator.service.list.label.iATACode = Código IATA
+
+administrator.service.list.button.create = Crear nuevo servicio
+
+administrator.service.form.label.name = Nombre
+administrator.service.form.label.picture = Imagen
+administrator.service.form.label.avgDwellTime = Tiempo medio de permanencia
+administrator.service.form.label.promotionCode = Código de promoción
+administrator.service.form.label.money = Descuento
+administrator.service.form.label.iATACode = Código IATA
+
+administrator.service.form.button.update = Actualizar este servicio
+administrator.service.form.button.delete = Borrar este servicio
+administrator.service.form.button.create = Crear este servicio

--- a/src/main/resources/WEB-INF/views/administrator/service/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/administrator/service/messages-es.i18n
@@ -6,7 +6,7 @@ administrator.service.list.label.picture = Imagen
 administrator.service.list.label.avgDwellTime = Tiempo de permanencia
 administrator.service.list.label.promotionCode = Código de promo
 administrator.service.list.label.money = Descuento
-administrator.service.list.label.iATACode = Código IATA
+administrator.service.list.label.iATACode = Aeropuerto
 
 administrator.service.list.button.create = Crear nuevo servicio
 
@@ -15,7 +15,7 @@ administrator.service.form.label.picture = Imagen
 administrator.service.form.label.avgDwellTime = Tiempo medio de permanencia
 administrator.service.form.label.promotionCode = Código de promoción
 administrator.service.form.label.money = Descuento
-administrator.service.form.label.iATACode = Código IATA
+administrator.service.form.label.airport = Aeropuerto
 
 administrator.service.form.button.update = Actualizar este servicio
 administrator.service.form.button.delete = Borrar este servicio

--- a/src/main/resources/WEB-INF/views/administrator/service/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/administrator/service/messages-es.i18n
@@ -20,3 +20,9 @@ administrator.service.form.label.airport = Aeropuerto
 administrator.service.form.button.update = Actualizar este servicio
 administrator.service.form.button.delete = Borrar este servicio
 administrator.service.form.button.create = Crear este servicio
+
+administrator.service.create.promotion-code-must-be-unique = Este código de promoción ya ha sido registrado
+administrator.service.create.airport-does-not-exist = Escoge un aeropuerto
+
+administrator.service.update.promotion-code-must-be-unique = Este código de promoción ya ha sido registrado
+administrator.service.update.airport-does-not-exist = Escoge un aeropuerto

--- a/src/main/resources/WEB-INF/views/fragments/menu-en.i18n
+++ b/src/main/resources/WEB-INF/views/fragments/menu-en.i18n
@@ -33,6 +33,7 @@ master.menu.anonymous.estegn10-favourite-link = 53962653F: Gómez Navarro, Esteb
 
 master.menu.administrator = Administrator
 master.menu.administrator.list-user-accounts = List user accounts
+master.menu.administrator.list-services = List services
 master.menu.administrator.populate-db-initial = Populate DB (initial)
 master.menu.administrator.populate-db-sample = Populate DB (samples)
 master.menu.administrator.shut-system-down = Shut system down

--- a/src/main/resources/WEB-INF/views/fragments/menu-en.i18n
+++ b/src/main/resources/WEB-INF/views/fragments/menu-en.i18n
@@ -34,6 +34,7 @@ master.menu.anonymous.estegn10-favourite-link = 53962653F: Gómez Navarro, Esteb
 master.menu.administrator = Administrator
 master.menu.administrator.list-user-accounts = List user accounts
 master.menu.administrator.list-services = List services
+master.menu.administrator.create-services = Create services
 master.menu.administrator.populate-db-initial = Populate DB (initial)
 master.menu.administrator.populate-db-sample = Populate DB (samples)
 master.menu.administrator.shut-system-down = Shut system down

--- a/src/main/resources/WEB-INF/views/fragments/menu-es.i18n
+++ b/src/main/resources/WEB-INF/views/fragments/menu-es.i18n
@@ -33,6 +33,7 @@ master.menu.anonymous.estegn10-favourite-link = 53962653F: Gómez Navarro, Esteb
 
 master.menu.administrator = Administrador
 master.menu.administrator.list-user-accounts = Ver cuentas de usuario
+master.menu.administrator.list-services = Ver servicios
 master.menu.administrator.populate-db-initial = Poblar BD (inicial)
 master.menu.administrator.populate-db-sample = Poblar BD (ejemplos)
 master.menu.administrator.shut-system-down = Parar el sistema

--- a/src/main/resources/WEB-INF/views/fragments/menu-es.i18n
+++ b/src/main/resources/WEB-INF/views/fragments/menu-es.i18n
@@ -34,6 +34,7 @@ master.menu.anonymous.estegn10-favourite-link = 53962653F: Gómez Navarro, Esteb
 master.menu.administrator = Administrador
 master.menu.administrator.list-user-accounts = Ver cuentas de usuario
 master.menu.administrator.list-services = Ver servicios
+master.menu.administrator.create-services = Crear servicios
 master.menu.administrator.populate-db-initial = Poblar BD (inicial)
 master.menu.administrator.populate-db-sample = Poblar BD (ejemplos)
 master.menu.administrator.shut-system-down = Parar el sistema

--- a/src/main/resources/WEB-INF/views/fragments/menu.jsp
+++ b/src/main/resources/WEB-INF/views/fragments/menu.jsp
@@ -41,6 +41,7 @@
 			<acme:menu-suboption code="master.menu.administrator.list-user-accounts" action="/administrator/user-account/list"/>
 			<acme:menu-separator/>
 			<acme:menu-suboption code="master.menu.administrator.list-services" action="/administrator/service/list"/>
+			<acme:menu-suboption code="master.menu.administrator.create-services" action="/administrator/service/create"/>
 			<acme:menu-separator/>
 			<acme:menu-suboption code="master.menu.administrator.populate-db-initial" action="/administrator/system/populate-initial"/>
 			<acme:menu-suboption code="master.menu.administrator.populate-db-sample" action="/administrator/system/populate-sample"/>			

--- a/src/main/resources/WEB-INF/views/fragments/menu.jsp
+++ b/src/main/resources/WEB-INF/views/fragments/menu.jsp
@@ -40,6 +40,8 @@
 		<acme:menu-option code="master.menu.administrator" access="hasRealm('Administrator')">
 			<acme:menu-suboption code="master.menu.administrator.list-user-accounts" action="/administrator/user-account/list"/>
 			<acme:menu-separator/>
+			<acme:menu-suboption code="master.menu.administrator.list-services" action="/administrator/service/list"/>
+			<acme:menu-separator/>
 			<acme:menu-suboption code="master.menu.administrator.populate-db-initial" action="/administrator/system/populate-initial"/>
 			<acme:menu-suboption code="master.menu.administrator.populate-db-sample" action="/administrator/system/populate-sample"/>			
 			<acme:menu-separator/>


### PR DESCRIPTION
Se han añadido las operaciones de listar, añadir, mostrar, editar y borrar servicios estando registrado como administrador.

Es solo eso, no se necesita tutorial para saber cómo furula. Una cosa chula que la imagen que añadas en el servicio que vayas a crear aparecerá de forma aleatoria abajo en la página.