### PR TITLE
feat: :sparkles: Conversión de un usuario a cliente añadida

### DIFF
--- a/src/main/java/acme/features/authenticated/customer/AuthenticatedCustomerController.java
+++ b/src/main/java/acme/features/authenticated/customer/AuthenticatedCustomerController.java
@@ -1,0 +1,33 @@
+
+package acme.features.authenticated.customer;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.principals.Authenticated;
+import acme.client.controllers.AbstractGuiController;
+import acme.client.controllers.GuiController;
+import acme.realms.Customer;
+
+@GuiController
+public class AuthenticatedCustomerController extends AbstractGuiController<Authenticated, Customer> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private AuthenticatedCustomerUpdateService	updateService;
+
+	@Autowired
+	private AuthenticatedCustomerCreateService	createService;
+
+	// Constructors -----------------------------------------------------------
+
+
+	@PostConstruct
+	protected void initialise() {
+		super.addBasicCommand("update", this.updateService);
+		super.addBasicCommand("create", this.createService);
+	}
+
+}

--- a/src/main/java/acme/features/authenticated/customer/AuthenticatedCustomerCreateService.java
+++ b/src/main/java/acme/features/authenticated/customer/AuthenticatedCustomerCreateService.java
@@ -1,0 +1,93 @@
+
+package acme.features.authenticated.customer;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.models.Dataset;
+import acme.client.components.principals.Authenticated;
+import acme.client.components.principals.UserAccount;
+import acme.client.helpers.PrincipalHelper;
+import acme.client.services.AbstractGuiService;
+import acme.client.services.GuiService;
+import acme.realms.Customer;
+
+@GuiService
+public class AuthenticatedCustomerCreateService extends AbstractGuiService<Authenticated, Customer> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private AuthenticatedCustomerRepository repository;
+
+	// AbstractService<Authenticated, Provider> ---------------------------
+
+
+	@Override
+	public void authorise() {
+		boolean status;
+
+		status = !super.getRequest().getPrincipal().hasRealmOfType(Customer.class);
+
+		super.getResponse().setAuthorised(status);
+	}
+
+	@Override
+	public void load() {
+		Customer object;
+		int userAccountId;
+		UserAccount userAccount;
+
+		userAccountId = super.getRequest().getPrincipal().getAccountId();
+		userAccount = this.repository.findUserAccountById(userAccountId);
+
+		object = new Customer();
+		object.setUserAccount(userAccount);
+
+		super.getBuffer().addData(object);
+	}
+
+	@Override
+	public void bind(final Customer object) {
+		assert object != null;
+
+		super.bindObject(object, "identifier", "phoneNumber", "physicalAddress", "city", "country", "earnedPoints");
+
+	}
+
+	@Override
+	public void validate(final Customer object) {
+		assert object != null;
+
+		Collection<Customer> customers = this.repository.findAllCustomers();
+		Collection<String> customerIds = customers.stream().map(Customer::getIdentifier).toList();
+
+		if (object.getIdentifier() != null)
+			super.state(!customerIds.contains(object.getIdentifier()), "identifier", "authenticated.customer.create.not-unique-identifier");
+	}
+
+	@Override
+	public void perform(final Customer object) {
+		assert object != null;
+
+		this.repository.save(object);
+	}
+
+	@Override
+	public void unbind(final Customer object) {
+		assert object != null;
+
+		Dataset dataset;
+		dataset = super.unbindObject(object, "identifier", "phoneNumber", "physicalAddress", "city", "country", "earnedPoints");
+
+		super.getResponse().addData(dataset);
+	}
+
+	@Override
+	public void onSuccess() {
+		if (super.getRequest().getMethod().equals("POST"))
+			PrincipalHelper.handleUpdate();
+	}
+
+}

--- a/src/main/java/acme/features/authenticated/customer/AuthenticatedCustomerRepository.java
+++ b/src/main/java/acme/features/authenticated/customer/AuthenticatedCustomerRepository.java
@@ -1,0 +1,26 @@
+
+package acme.features.authenticated.customer;
+
+import java.util.Collection;
+
+import org.springframework.data.jpa.repository.Query;
+
+import acme.client.components.principals.UserAccount;
+import acme.client.repositories.AbstractRepository;
+import acme.realms.Customer;
+
+public interface AuthenticatedCustomerRepository extends AbstractRepository {
+
+	@Query("SELECT c FROM Customer c WHERE c.userAccount.id = :id")
+	Customer findCustomerByUserAccountId(int id);
+
+	@Query("SELECT c FROM Customer c")
+	Collection<Customer> findAllCustomers();
+
+	@Query("SELECT ua FROM UserAccount ua WHERE ua.id = :id")
+	UserAccount findUserAccountById(int id);
+
+	@Query("SELECT c FROM Customer c WHERE c.id = :id")
+	Customer findCustomerById(int id);
+
+}

--- a/src/main/java/acme/features/authenticated/customer/AuthenticatedCustomerUpdateService.java
+++ b/src/main/java/acme/features/authenticated/customer/AuthenticatedCustomerUpdateService.java
@@ -1,0 +1,89 @@
+
+package acme.features.authenticated.customer;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import acme.client.components.models.Dataset;
+import acme.client.components.principals.Authenticated;
+import acme.client.helpers.PrincipalHelper;
+import acme.client.services.AbstractGuiService;
+import acme.client.services.GuiService;
+import acme.realms.Customer;
+
+@GuiService
+public class AuthenticatedCustomerUpdateService extends AbstractGuiService<Authenticated, Customer> {
+
+	// Internal state ---------------------------------------------------------
+
+	@Autowired
+	private AuthenticatedCustomerRepository repository;
+
+	// AbstractService<Authenticated, Provider> ---------------------------
+
+
+	@Override
+	public void authorise() {
+		boolean status;
+
+		status = super.getRequest().getPrincipal().hasRealmOfType(Customer.class);
+
+		super.getResponse().setAuthorised(status);
+	}
+
+	@Override
+	public void load() {
+		Customer customer;
+		int userAccountId;
+
+		userAccountId = super.getRequest().getPrincipal().getAccountId();
+		customer = this.repository.findCustomerByUserAccountId(userAccountId);
+
+		super.getBuffer().addData(customer);
+	}
+
+	@Override
+	public void bind(final Customer object) {
+		assert object != null;
+
+		super.bindObject(object, "identifier", "phoneNumber", "physicalAddress", "city", "country", "earnedPoints");
+
+	}
+
+	@Override
+	public void validate(final Customer customer) {
+		assert customer != null;
+
+		Collection<Customer> customers = this.repository.findAllCustomers();
+		Collection<String> customerIds = customers.stream().map(Customer::getIdentifier).toList();
+		Customer oldCustomer = this.repository.findCustomerById(customer.getId());
+
+		if (customer.getIdentifier() != null && !oldCustomer.getIdentifier().equals(customer.getIdentifier()))
+			super.state(!customerIds.contains(customer.getIdentifier()), "identifier", "authenticated.customer.create.not-unique-identifier");
+	}
+
+	@Override
+	public void perform(final Customer object) {
+		assert object != null;
+
+		this.repository.save(object);
+	}
+
+	@Override
+	public void unbind(final Customer object) {
+		assert object != null;
+
+		Dataset dataset;
+		dataset = super.unbindObject(object, "identifier", "phoneNumber", "physicalAddress", "city", "country", "earnedPoints");
+
+		super.getResponse().addData(dataset);
+	}
+
+	@Override
+	public void onSuccess() {
+		if (super.getRequest().getMethod().equals("POST"))
+			PrincipalHelper.handleUpdate();
+	}
+
+}

--- a/src/main/resources/WEB-INF/views/authenticated/customer/form.jsp
+++ b/src/main/resources/WEB-INF/views/authenticated/customer/form.jsp
@@ -1,0 +1,35 @@
+<%--
+- form.jsp
+-
+- Copyright (C) 2012-2025 Rafael Corchuelo.
+-
+- In keeping with the traditional purpose of furthering education and research, it is
+- the policy of the copyright owner to permit non-commercial use and redistribution of
+- this software. It has been tested carefully, but it is not guaranteed for any particular
+- purposes.  The copyright owner does not offer any warranties or representations, nor do
+- they accept any liabilities with respect to them.
+--%>
+
+<%@page%>
+
+<%@taglib prefix="jstl" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@taglib prefix="acme" uri="http://acme-framework.org/"%>
+
+<acme:form>
+    <!-- Uso textbox debido a un bug visual en integer -->
+	<acme:input-textbox code="authenticated.customer.form.label.identifier" path="identifier" placeholder="authenticated.customer.form.placeholder.identifier" />
+	<acme:input-textbox code="authenticated.customer.form.label.phoneNumber" path="phoneNumber" placeholder="authenticated.customer.form.placeholder.phoneNumber"/>
+	<acme:input-textbox code="authenticated.customer.form.label.physicalAddress" path="physicalAddress"/>
+	<acme:input-textbox code="authenticated.customer.form.label.city" path="city"/>
+	<acme:input-textbox code="authenticated.customer.form.label.country" path="country"/>
+	<acme:input-textbox code="authenticated.customer.form.label.earnedPoints" path="earnedPoints" placeholder="authenticated.customer.form.placeholder.earnedPoints"/>	
+	
+	<jstl:if test="${_command == 'create'}">
+		<acme:submit code="authenticated.customer.form.button.create" action="/authenticated/customer/create"/>
+	</jstl:if>
+	
+	<jstl:if test="${_command == 'update'}">
+		<acme:submit code="authenticated.customer.form.button.update" action="/authenticated/customer/update"/>
+	</jstl:if>
+	
+</acme:form>

--- a/src/main/resources/WEB-INF/views/authenticated/customer/messages-en.i18n
+++ b/src/main/resources/WEB-INF/views/authenticated/customer/messages-en.i18n
@@ -1,0 +1,17 @@
+authenticated.customer.form.title = Customer form
+
+authenticated.customer.form.label.identifier = Identifier: 
+authenticated.customer.form.label.phoneNumber = Phone number:
+authenticated.customer.form.label.physicalAddress = Physical address:
+authenticated.customer.form.label.city = City:
+authenticated.customer.form.label.country = Country:
+authenticated.customer.form.label.earnedPoints = Earned points:
+
+authenticated.customer.form.placeholder.identifier = ABC123456
+authenticated.customer.form.placeholder.earnedPoints = 300
+authenticated.customer.form.placeholder.phoneNumber = 643647352
+
+authenticated.customer.form.button.create = Register
+authenticated.customer.form.button.update = Update
+
+authenticated.customer.create.not-unique-identifier = This identifier is already in use

--- a/src/main/resources/WEB-INF/views/authenticated/customer/messages-es.i18n
+++ b/src/main/resources/WEB-INF/views/authenticated/customer/messages-es.i18n
@@ -1,0 +1,17 @@
+authenticated.customer.form.title = Detalles de cliente
+
+authenticated.customer.form.label.identifier = Identificador: 
+authenticated.customer.form.label.phoneNumber = Número de teléfono:
+authenticated.customer.form.label.physicalAddress = Dirección física:
+authenticated.customer.form.label.city = Ciudad:
+authenticated.customer.form.label.country = País:
+authenticated.customer.form.label.earnedPoints = Puntos obtenidos:
+
+authenticated.customer.form.placeholder.identifier = ABC123456
+authenticated.customer.form.placeholder.earnedPoints = 300
+authenticated.customer.form.placeholder.phoneNumber = 643647352
+
+authenticated.customer.form.button.create = Registrar
+authenticated.customer.form.button.update = Actualizar
+
+authenticated.customer.create.not-unique-identifier = Este identificador ya está en uso

--- a/src/main/resources/WEB-INF/views/fragments/menu-en.i18n
+++ b/src/main/resources/WEB-INF/views/fragments/menu-en.i18n
@@ -72,3 +72,5 @@ master.menu.user-account.become-consumer = Become a consumer
 master.menu.user-account.consumer-profile = Consumer profile
 master.menu.user-account.become-manager = Become a manager
 master.menu.user-account.manager-profile =  Manager profile
+master.menu.user-account.become-customer = Become a customer
+master.menu.user-account.customer-profile =  Customer profile

--- a/src/main/resources/WEB-INF/views/fragments/menu-es.i18n
+++ b/src/main/resources/WEB-INF/views/fragments/menu-es.i18n
@@ -72,3 +72,5 @@ master.menu.user-account.become-consumer = Hazte consumidor
 master.menu.user-account.consumer-profile = Perfil de consumidor
 master.menu.user-account.become-manager = Hazte manager
 master.menu.user-account.manager-profile =  Perfil de manager
+master.menu.user-account.become-customer = Hazte cliente
+master.menu.user-account.customer-profile =  Perfil de cliente

--- a/src/main/resources/WEB-INF/views/fragments/menu.jsp
+++ b/src/main/resources/WEB-INF/views/fragments/menu.jsp
@@ -78,6 +78,8 @@
 			<acme:menu-suboption code="master.menu.user-account.consumer-profile" action="/authenticated/consumer/update" access="hasRealm('Consumer')"/>
 			<acme:menu-suboption code="master.menu.user-account.become-manager" action="/authenticated/manager/create" access="!hasRealm('Manager')"/>
 			<acme:menu-suboption code="master.menu.user-account.manager-profile" action="/authenticated/manager/update" access="hasRealm('Manager')"/>
+			<acme:menu-suboption code="master.menu.user-account.become-customer" action="/authenticated/customer/create" access="!hasRealm('Customer')"/>
+			<acme:menu-suboption code="master.menu.user-account.customer-profile" action="/authenticated/customer/update" access="hasRealm('Customer')"/>
 		</acme:menu-option>
 	</acme:menu-right>
 </acme:menu-bar>


### PR DESCRIPTION
Se ha añadido la funcionalidad necesaria para que un usuario que no sea un cliente pueda convertirse en uno.

Para testearlo, primero habría que iniciar sesión como un usuario que NO sea customer. Tras eso, al pulsar Account/Cuenta, habrá una opción para volverse un Customer. Una vez convertido en Customer, la opción anterior habrá desaparecido, y en su lugar se podrán actualizar los datos del Customer actual.

Refs: #193